### PR TITLE
Fixed issue where JSDoc types were not being imported from node module.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
     "noImplicitThis": true,
     "alwaysStrict": true
   },
-  "exclude": [
-    "node_modules",
-    "**/node_modules/*"
+  "include": [
+    "node_modules/@d4kmor/**/*.js"
   ]
 }


### PR DESCRIPTION
1. The trick to getting JSDoc types from a node module is in the tsconfig.json setup. You should use "exclude" with node_modules, otherwise TypeScript will ignore the types in the JavaScript files.
2. Instead use "include" with the JavaScript moduels with JSDoc types that you want imported. This will force TypeScript to anylize and import those types to your project.
3. With this fix in place, hovering over "foo" now show the correct type information.